### PR TITLE
Add reset and exit commands to A* CLI

### DIFF
--- a/A_Stern_Algo_3.py
+++ b/A_Stern_Algo_3.py
@@ -283,83 +283,109 @@ if __name__ == "__main__":
 
     stop_names = list(graph.nodes.keys())
 
-    start_query = input("Start stop name: ").strip()
-    start = resolve_stop(start_query, stop_names)
-    if start is None:
-        print(f"Unknown stop: {start_query}")
-        raise SystemExit(1)
+    while True:
+        start_query = input("Start stop name (or 'reset'/'exit'): ").strip()
+        if start_query.lower() == "exit":
+            break
+        if start_query.lower() == "reset":
+            continue
+        start = resolve_stop(start_query, stop_names)
+        if start is None:
+            print(f"Unknown stop: {start_query}")
+            continue
 
-    goal_query = input("Goal stop name: ").strip()
-    goal = resolve_stop(goal_query, stop_names)
-    if goal is None:
-        print(f"Unknown stop: {goal_query}")
-        raise SystemExit(1)
+        goal_query = input("Goal stop name (or 'reset'/'exit'): ").strip()
+        if goal_query.lower() == "exit":
+            break
+        if goal_query.lower() == "reset":
+            continue
+        goal = resolve_stop(goal_query, stop_names)
+        if goal is None:
+            print(f"Unknown stop: {goal_query}")
+            continue
 
-    choice_time = input("Zeit wählen [now/abfahrt/anreise]: ").strip().lower()
-    if choice_time == "now":
-        now = datetime.now()
-        start_minutes = now.hour * 60 + now.minute + now.second / 60.0
-        reverse = False
-    elif choice_time == "abfahrt":
-        dep_str = input("Abfahrtszeit (HH:MM): ").strip()
-        start_minutes = parse_time_to_minutes(dep_str)
-        reverse = False
-    elif choice_time == "anreise":
-        arr_str = input("Ankunftszeit (HH:MM): ").strip()
-        start_minutes = parse_time_to_minutes(arr_str)
-        reverse = True
-    else:
-        print("Ungültige Wahl, benutze aktuelle Zeit.")
-        now = datetime.now()
-        start_minutes = now.hour * 60 + now.minute + now.second / 60.0
-        reverse = False
+        choice_time = input("Zeit wählen [now/abfahrt/anreise] (or 'reset'/'exit'): ").strip().lower()
+        if choice_time == "exit":
+            break
+        if choice_time == "reset":
+            continue
+        if choice_time == "now":
+            now = datetime.now()
+            start_minutes = now.hour * 60 + now.minute + now.second / 60.0
+            reverse = False
+        elif choice_time == "abfahrt":
+            dep_str = input("Abfahrtszeit (HH:MM) (or 'reset'/'exit'): ").strip()
+            if dep_str.lower() == "exit":
+                break
+            if dep_str.lower() == "reset":
+                continue
+            start_minutes = parse_time_to_minutes(dep_str)
+            reverse = False
+        elif choice_time == "anreise":
+            arr_str = input("Ankunftszeit (HH:MM) (or 'reset'/'exit'): ").strip()
+            if arr_str.lower() == "exit":
+                break
+            if arr_str.lower() == "reset":
+                continue
+            start_minutes = parse_time_to_minutes(arr_str)
+            reverse = True
+        else:
+            print("Ungültige Wahl, benutze aktuelle Zeit.")
+            now = datetime.now()
+            start_minutes = now.hour * 60 + now.minute + now.second / 60.0
+            reverse = False
 
-    choice = input("Sort route by time or transfers? [time/transfers]: ").strip().lower()
-    if choice.startswith("time"):
-        time_weight = 1.0
-        penalty = 0.1
-    elif choice.startswith("transfers"):
-        time_weight = 0.0
-        penalty = 1.0
-    else:
-        print("Invalid choice. Defaulting to time.")
-        time_weight = 1.0
-        penalty = 0.1
+        choice = input("Sort route by time or transfers? [time/transfers] (or 'reset'/'exit'): ").strip().lower()
+        if choice == "exit":
+            break
+        if choice == "reset":
+            continue
+        if choice.startswith("time"):
+            time_weight = 1.0
+            penalty = 0.1
+        elif choice.startswith("transfers"):
+            time_weight = 0.0
+            penalty = 1.0
+        else:
+            print("Invalid choice. Defaulting to time.")
+            time_weight = 1.0
+            penalty = 0.1
 
 
-    if reverse:
-        path = astar_reverse(
-            graph,
-            start,
-            goal,
-            heuristic=null_heuristic,
-            arrival_time=start_minutes,
-            time_weight=time_weight,
-            transfer_penalty=penalty,
-        )
-    else:
-        path = astar(
-            graph,
-            start,
-            goal,
-            heuristic=null_heuristic,
-            start_time=start_minutes,
-            time_weight=time_weight,
-            transfer_penalty=penalty,
-        )
+        if reverse:
+            path = astar_reverse(
+                graph,
+                start,
+                goal,
+                heuristic=null_heuristic,
+                arrival_time=start_minutes,
+                time_weight=time_weight,
+                transfer_penalty=penalty,
+            )
+        else:
+            path = astar(
+                graph,
+                start,
+                goal,
+                heuristic=null_heuristic,
+                start_time=start_minutes,
+                time_weight=time_weight,
+                transfer_penalty=penalty,
+            )
 
-    if path:
-        print("Found path:")
-        start_stop = path[0][0]
-        print(f"Start at {start_stop}")
-        for step in path[1:]:
-            if len(step) == 3:
-                stop, line, arr = step
-                line_str = line if line is not None else "start"
-                print(f"Take {line_str} to {stop} arriving at {minutes_to_hhmm(arr)}")
-            else:
-                stop, line = step
-                line_str = line if line is not None else "start"
-                print(f"Take {line_str} to {stop}")
-    else:
-        print("No path found.")
+        if path:
+            print("Found path:")
+            start_stop = path[0][0]
+            print(f"Start at {start_stop}")
+            for step in path[1:]:
+                if len(step) == 3:
+                    stop, line, arr = step
+                    line_str = line if line is not None else "start"
+                    print(f"Take {line_str} to {stop} arriving at {minutes_to_hhmm(arr)}")
+                else:
+                    stop, line = step
+                    line_str = line if line is not None else "start"
+                    print(f"Take {line_str} to {stop}")
+        else:
+            print("No path found.")
+


### PR DESCRIPTION
## Summary
- allow repeated route searches
- add `reset` to restart the input questions
- add `exit` to quit

## Testing
- `python -m py_compile A_Stern_Algo_3.py`

------
https://chatgpt.com/codex/tasks/task_e_6853cd50e0e4832e98e62702a2573806