### PR TITLE
Handle polygon geometries in route map

### DIFF
--- a/visualization_osmnx.py
+++ b/visualization_osmnx.py
@@ -26,13 +26,25 @@ def save_route_map(
     """
 
     stops = [step[0] for step in path]
-    try:
-        gdf = ox.geocode_to_gdf(stops)
-    except Exception as exc:
-        print(f"Could not geocode stops: {exc}")
-        return None
-
-    coords = [(row.geometry.y, row.geometry.x) for _, row in gdf.iterrows()]
+    coords = []
+    for stop in stops:
+        try:
+            geom = ox.geocode_to_gdf(stop).loc[0, "geometry"]
+        except Exception:
+            try:
+                result = ox.geocode(stop)
+            except Exception as exc:
+                print(f"Could not geocode stop '{stop}': {exc}")
+                return None
+            if hasattr(result, "geom_type"):
+                geom = result
+            else:
+                lat, lon = result
+                coords.append((lat, lon))
+                continue
+        if geom.geom_type in {"Polygon", "MultiPolygon"}:
+            geom = geom.centroid
+        coords.append((geom.y, geom.x))
     m = folium.Map(location=coords[0], zoom_start=13)
     folium.PolyLine(coords, color="blue").add_to(m)
     for (step, (lat, lon)) in zip(path, coords):


### PR DESCRIPTION
## Summary
- update `save_route_map` so geocoded polygons are converted to centroids
- ensure geocoding works across osmnx versions without `buffer_dist`

## Testing
- `python -m py_compile visualization_osmnx.py`


------
https://chatgpt.com/codex/tasks/task_e_6854178dce88832e91061fa55b167556