### PR TITLE
Add OSMnx based routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,16 @@ Bei dem Projekt haben wir auch noch die Einschränkung, dass wir nur eine Geocod
 Für den ÖPNV könnten wir die GTFs-Datenbank nutzen, mal schauen wie weit die uns bringt.
 Für Rad, Fuß und MV sollten wir OSMNX nutzen (auch eine Datenbank)
 
-Für das gesamte Projekt gilt, dass der Code modular aufgebaut werden muss. 
+Für das gesamte Projekt gilt, dass der Code modular aufgebaut werden muss.
 Und wenn wir genügend Zeit haben (optional) wäre eine Visualisierung des ganzen (Wie bei Maps bspw.) ganz cool.“
+
+## Voraussetzungen
+
+Für die Visualisierung wird nun das Paket `osmnx` benötigt:
+
+```bash
+pip install osmnx
+```
+
+In `save_route_map` kann über den Parameter `network_type` das genutzte
+OSM-Netz gewählt werden (z.B. `"drive"`, `"walk"`, `"bike"`, `"rail"`).

--- a/visualization_osmnx.py
+++ b/visualization_osmnx.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from typing import List, Tuple, Optional
 
 import folium
+import osmnx as ox
+import networkx as nx
 
 from A_Stern_Algo_3 import (
     Graph,
@@ -19,11 +21,15 @@ def save_route_map(
     graph: Graph,
     path: List[Tuple[str, Optional[str], float]],
     filename: str = "route_map.html",
+    network_type: str = "drive",
 ) -> Optional[str]:
-    """Save the list of stops as an interactive HTML map.
+    """Save the list of stops as an interactive HTML map using OSM data.
 
-    Coordinates are looked up from ``graph``. The resulting HTML file is
-    returned or ``None`` if any stop lacks coordinate data.
+    Coordinates are looked up from ``graph``.  Routes between consecutive
+    stops are calculated on an OpenStreetMap network.  ``network_type`` can
+    be used to choose the network, e.g. ``"drive"`` or ``"walk"``.  The
+    resulting HTML file is returned or ``None`` if any stop lacks coordinate
+    data.
     """
 
     coords = []
@@ -34,8 +40,32 @@ def save_route_map(
             print(f"No coordinates for stop '{stop}'")
             return None
         coords.append((node.lat, node.lon))
+
+    if not coords:
+        return None
+
     m = folium.Map(location=coords[0], zoom_start=13)
-    folium.PolyLine(coords, color="blue").add_to(m)
+
+    # Build segments along the OSM network for each pair of stops
+    for i in range(len(coords) - 1):
+        origin = coords[i]
+        dest = coords[i + 1]
+        north = max(origin[0], dest[0]) + 0.005
+        south = min(origin[0], dest[0]) - 0.005
+        east = max(origin[1], dest[1]) + 0.005
+        west = min(origin[1], dest[1]) - 0.005
+        try:
+            G = ox.graph_from_bbox(north, south, east, west, network_type=network_type)
+            orig_node = ox.nearest_nodes(G, origin[1], origin[0])
+            dest_node = ox.nearest_nodes(G, dest[1], dest[0])
+            route = nx.shortest_path(G, orig_node, dest_node, weight="length")
+            route_gdf = ox.route_to_gdf(G, route)
+            route_coords = [(lat, lon) for lon, lat in route_gdf.geometry.iloc[0].coords]
+            folium.PolyLine(route_coords, color="blue").add_to(m)
+        except Exception:
+            # Fallback to straight line if routing fails
+            folium.PolyLine([origin, dest], color="blue", dash_array="5").add_to(m)
+
     for (step, (lat, lon)) in zip(path, coords):
         stop, line, arr = step
         popup = f"{stop} ({minutes_to_hhmm(arr)})"


### PR DESCRIPTION
## Summary
- compute road network routes using OSMnx in `save_route_map`
- allow choosing the network type when saving a route map
- document new `osmnx` requirement and `network_type` option

## Testing
- `python -m py_compile A_Stern_Algo_3.py visualization_osmnx.py`

------
https://chatgpt.com/codex/tasks/task_e_68542327de8c832eb99f391f654678af