### PR TITLE
Add address routing option

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,5 +4,8 @@ Routes are visualized automatically using :func:`save_route_map` from the
 ``visualization_osmnx`` module.
 """
 from cli import run_cli
+import sys
+
 if __name__ == "__main__":
-    run_cli()
+    nt = sys.argv[1] if len(sys.argv) > 1 else "drive"
+    run_cli(network_type=nt)


### PR DESCRIPTION
## Summary
- allow entering stop names or free addresses in `cli.py`
- integrate `geocode_address` and `find_osm_route`
- support selecting `network_type` for street routing and map output
- pass optional network type via `main.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857d3bf9de4832e895ceeea58155326