### PR TITLE
Add map visualization for address routing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9,7 +9,7 @@ from routing import (
 )
 from geocoding import geocode_address
 from osm_routing import find_osm_route
-from visualization_osmnx import save_route_map
+from visualization_osmnx import save_route_map, save_coords_map
 
 def run_cli(network_type: str = "drive") -> None:
     """Interactive command line interface using :func:`find_route` or
@@ -142,6 +142,9 @@ def run_cli(network_type: str = "drive") -> None:
             print("Route coordinates:")
             for lat, lon in coords_path:
                 print(f"  {lat:.5f}, {lon:.5f}")
+            filename = save_coords_map(coords_path, network_type=network_type)
+            if filename:
+                print(f"Map saved to {filename}")
 
 
 if __name__ == "__main__":

--- a/visualization_osmnx.py
+++ b/visualization_osmnx.py
@@ -63,3 +63,45 @@ def save_route_map(
 
     m.save(filename)
     return filename
+
+
+def save_coords_map(
+    coords: List[Tuple[float, float]],
+    filename: str = "osm_route_map.html",
+    network_type: str = "drive",
+) -> Optional[str]:
+    """Save a coordinate path as an interactive HTML map.
+
+    The list of coordinate pairs ``coords`` is connected along an
+    OpenStreetMap network if possible. ``network_type`` chooses the OSM
+    network like ``"drive"`` or ``"walk"``.
+    """
+
+    if not coords:
+        return None
+
+    m = folium.Map(location=coords[0], zoom_start=13)
+
+    for i in range(len(coords) - 1):
+        origin = coords[i]
+        dest = coords[i + 1]
+        north = max(origin[0], dest[0]) + 0.005
+        south = min(origin[0], dest[0]) - 0.005
+        east = max(origin[1], dest[1]) + 0.005
+        west = min(origin[1], dest[1]) - 0.005
+        try:
+            G = ox.graph_from_bbox(north, south, east, west, network_type=network_type)
+            orig_node = ox.nearest_nodes(G, origin[1], origin[0])
+            dest_node = ox.nearest_nodes(G, dest[1], dest[0])
+            route = nx.shortest_path(G, orig_node, dest_node, weight="length")
+            route_gdf = ox.route_to_gdf(G, route)
+            route_coords = [(lat, lon) for lon, lat in route_gdf.geometry.iloc[0].coords]
+            folium.PolyLine(route_coords, color="blue").add_to(m)
+        except Exception:
+            folium.PolyLine([origin, dest], color="blue", dash_array="5").add_to(m)
+
+    for lat, lon in coords:
+        folium.Marker([lat, lon]).add_to(m)
+
+    m.save(filename)
+    return filename


### PR DESCRIPTION
## Summary
- output interactive HTML maps when routing between arbitrary addresses
- implement `save_coords_map` helper in `visualization_osmnx.py`
- call `save_coords_map` from `cli.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python graph.py`
- `python main.py drive <<'EOF'
exit
EOF` *(fails: ModuleNotFoundError: No module named 'osmnx')*

------
https://chatgpt.com/codex/tasks/task_e_6857cec1721c832eb98a4284ada9284a