### PR TITLE
Add transport mode selection with address handling

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6,29 +6,43 @@ from routing import (
     resolve_stop,
     parse_time_to_minutes,
     minutes_to_hhmm,
+    find_nearest_stop,
 )
 from geocoding import geocode_address
 from osm_routing import find_osm_route
 from visualization_osmnx import save_route_map, save_coords_map
 
 def run_cli(network_type: str = "drive") -> None:
-    """Interactive command line interface using :func:`find_route` or
-    :func:`find_osm_route`.
+    """Interactive command line interface for different routing modes.
 
-    ``network_type`` specifies the OSM network used for address routing and
-    map visualization.
+    ``network_type`` is used as default for car routing and map visualization.
     """
 
     graph = load_default_graph()
     stop_names = list(graph.nodes.keys())
 
     while True:
-        start_query = input("Start stop or address (or 'reset'/'exit'): ").strip()
+        start_query = input("Von wo? (Haltestelle oder Adresse, 'reset'/'exit'): ").strip()
         if start_query.lower() == "exit":
             break
         if start_query.lower() == "reset":
             continue
+
+        goal_query = input("Nach wo? (Haltestelle oder Adresse, 'reset'/'exit'): ").strip()
+        if goal_query.lower() == "exit":
+            break
+        if goal_query.lower() == "reset":
+            continue
+
+        mode = input("Verkehrsmittel [auto/rad/fuss/bahn] (or 'reset'/'exit'): ").strip().lower()
+        if mode == "exit":
+            break
+        if mode == "reset":
+            continue
+
         start = resolve_stop(start_query, stop_names)
+        goal = resolve_stop(goal_query, stop_names)
+
         if start is None:
             try:
                 start_coords = geocode_address(start_query)
@@ -42,12 +56,6 @@ def run_cli(network_type: str = "drive") -> None:
                 continue
             start_coords = (node.lat, node.lon)
 
-        goal_query = input("Goal stop or address (or 'reset'/'exit'): ").strip()
-        if goal_query.lower() == "exit":
-            break
-        if goal_query.lower() == "reset":
-            continue
-        goal = resolve_stop(goal_query, stop_names)
         if goal is None:
             try:
                 goal_coords = geocode_address(goal_query)
@@ -61,6 +69,19 @@ def run_cli(network_type: str = "drive") -> None:
                 continue
             goal_coords = (node.lat, node.lon)
 
+        if mode in {"auto", "rad", "fuss"}:
+            nt_map = {"auto": "drive", "rad": "bike", "fuss": "walk"}
+            nt = nt_map[mode]
+            coords_path = find_osm_route(start_coords, goal_coords, network_type=nt)
+            print("Route coordinates:")
+            for lat, lon in coords_path:
+                print(f"  {lat:.5f}, {lon:.5f}")
+            filename = save_coords_map(coords_path, network_type=nt)
+            if filename:
+                print(f"Map saved to {filename}")
+            continue
+
+        # Bahn routing with optional walking segments
         choice_time = input(
             "Zeit wählen [now/abfahrt/anreise] (or 'reset'/'exit'): "
         ).strip().lower()
@@ -102,49 +123,61 @@ def run_cli(network_type: str = "drive") -> None:
         if choice == "reset":
             continue
 
-        if start is not None and goal is not None:
-            path = find_route(
-                graph,
-                start,
-                goal,
-                start_minutes,
-                reverse=reverse,
-                sort_by=choice,
-            )
+        start_stop = start if start is not None else find_nearest_stop(graph, start_coords)
+        goal_stop = goal if goal is not None else find_nearest_stop(graph, goal_coords)
 
-            if path:
-                print("Found path:")
-                start_stop = path[0][0]
-                print(f"Start at {start_stop}")
-                for step in path[1:]:
-                    if len(step) == 3:
-                        stop, line, arr = step
-                        line_str = line if line is not None else "start"
-                        print(
-                            f"Take {line_str} to {stop} arriving at {minutes_to_hhmm(arr)}"
-                        )
-                    else:
-                        stop, line = step
-                        line_str = line if line is not None else "start"
-                        print(f"Take {line_str} to {stop}")
+        walk_start = None
+        if start is None and start_stop is not None:
+            node = graph.nodes.get(start_stop)
+            if node and node.lat is not None and node.lon is not None:
+                walk_start = find_osm_route(start_coords, (node.lat, node.lon), network_type="walk")
 
-                filename = save_route_map(graph, path, network_type=network_type)
-                if filename:
-                    print(f"Map saved to {filename}")
-            else:
-                print("No path found.")
-        else:
-            coords_path = find_osm_route(
-                start_coords,
-                goal_coords,
-                network_type=network_type,
-            )
-            print("Route coordinates:")
-            for lat, lon in coords_path:
-                print(f"  {lat:.5f}, {lon:.5f}")
-            filename = save_coords_map(coords_path, network_type=network_type)
+        walk_end = None
+        if goal is None and goal_stop is not None:
+            node = graph.nodes.get(goal_stop)
+            if node and node.lat is not None and node.lon is not None:
+                walk_end = find_osm_route((node.lat, node.lon), goal_coords, network_type="walk")
+
+        if start_stop is None or goal_stop is None:
+            print("Could not determine nearby stops for transit routing.")
+            continue
+
+        path = find_route(
+            graph,
+            start_stop,
+            goal_stop,
+            start_minutes,
+            reverse=reverse,
+            sort_by=choice,
+        )
+
+        if path:
+            print("Found path:")
+            start_stop_name = path[0][0]
+            print(f"Start at {start_stop_name}")
+            for step in path[1:]:
+                if len(step) == 3:
+                    stop, line, arr = step
+                    line_str = line if line is not None else "start"
+                    print(f"Take {line_str} to {stop} arriving at {minutes_to_hhmm(arr)}")
+                else:
+                    stop, line = step
+                    line_str = line if line is not None else "start"
+                    print(f"Take {line_str} to {stop}")
+
+            filename = save_route_map(graph, path, network_type="walk")
             if filename:
                 print(f"Map saved to {filename}")
+            if walk_start:
+                print("Fußweg zum Start:")
+                for lat, lon in walk_start:
+                    print(f"  {lat:.5f}, {lon:.5f}")
+            if walk_end:
+                print("Fußweg zum Ziel:")
+                for lat, lon in walk_end:
+                    print(f"  {lat:.5f}, {lon:.5f}")
+        else:
+            print("No path found.")
 
 
 if __name__ == "__main__":

--- a/routing.py
+++ b/routing.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import heapq
 import csv
 import difflib
+from math import radians, sin, cos, sqrt, atan2
 
 from graph import Graph
 
@@ -53,6 +54,31 @@ def resolve_stop(query: str, stop_names: List[str], cutoff: float = 0.6) -> Opti
     """Return the closest matching stop name for ``query`` or ``None``."""
     matches = difflib.get_close_matches(query, stop_names, n=1, cutoff=cutoff)
     return matches[0] if matches else None
+
+
+def haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Return distance in kilometers between two lat/lon pairs."""
+    r = 6371.0
+    dlat = radians(lat2 - lat1)
+    dlon = radians(lon2 - lon1)
+    a = sin(dlat / 2) ** 2 + cos(radians(lat1)) * cos(radians(lat2)) * sin(dlon / 2) ** 2
+    c = 2 * atan2(sqrt(a), sqrt(1 - a))
+    return r * c
+
+
+def find_nearest_stop(graph: Graph, coords: Tuple[float, float]) -> Optional[str]:
+    """Return the name of the stop closest to ``coords``."""
+    best_stop: Optional[str] = None
+    best_dist = float("inf")
+    lat, lon = coords
+    for name, node in graph.nodes.items():
+        if node.lat is None or node.lon is None:
+            continue
+        dist = haversine(lat, lon, node.lat, node.lon)
+        if dist < best_dist:
+            best_dist = dist
+            best_stop = name
+    return best_stop
 
 
 def load_graph_from_csv(path: str) -> Graph:


### PR DESCRIPTION
## Summary
- extend `routing` with helper functions to find nearest stop
- rework `run_cli` to ask for start and goal first and then choose the transport mode
- support automatic routing for car, bike and walking
- when using public transit, connect addresses to stops via walking segments

## Testing
- `python -m py_compile cli.py routing.py osm_routing.py visualization_osmnx.py graph.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_685d033db270832e91a0d63b1ad14656