### PR TITLE
Improve geocoding for Karlsruhe and query matching

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -33,6 +33,11 @@ def classify_query(query: str, stop_names: List[str]) -> Tuple[Optional[str], Op
     if stop:
         return stop, None
 
+    # Try again with a lower cutoff to catch partial or shorter names
+    stop = resolve_stop(query, stop_names, cutoff=0.6)
+    if stop:
+        return stop, None
+
     coords = geocode_address(query)
     return None, coords
 

--- a/geocoding.py
+++ b/geocoding.py
@@ -1,13 +1,44 @@
+"""Helpers for converting addresses to coordinates."""
+
 from typing import Tuple
 
+try:  # optional dependency
+    from geopy.geocoders import Nominatim
+except Exception:  # pragma: no cover - geopy might not be installed
+    Nominatim = None
+
 import osmnx as ox
+
+_VIEWBOX_KARLSRUHE = (8.2, 48.8, 8.9, 49.3)  # west, south, east, north
+
+_geolocator = None
+if Nominatim is not None:
+    _geolocator = Nominatim(user_agent="routing-demo")
 
 
 def geocode_address(query: str) -> Tuple[float, float]:
     """Return latitude and longitude for the given address query.
 
-    This function uses :func:`osmnx.geocode` to look up the coordinates and
-    returns them as a ``(lat, lon)`` tuple.
+    A bounding box around the Karlsruhe district is applied to improve
+    accuracy. If ``geopy`` is available, it is used with ``viewbox`` and
+    ``bounded=True``. Otherwise ``osmnx.geocode`` is used as a fallback
+    without a bounding box.  ``ValueError`` is raised when no result is found.
     """
-    lat, lon = ox.geocode(query)
-    return lat, lon
+
+    if _geolocator is not None:
+        loc = _geolocator.geocode(
+            query,
+            viewbox=_VIEWBOX_KARLSRUHE,
+            bounded=True,
+        )
+        if loc is None:
+            raise ValueError(f"Address not found: {query}")
+        return loc.latitude, loc.longitude
+
+    if hasattr(ox, "geocode"):
+        lat, lon = ox.geocode(query)
+        return lat, lon
+
+    raise RuntimeError(
+        "No geocoder available (geopy or osmnx required for geocoding)"
+    )


### PR DESCRIPTION
## Summary
- restrict address geocoding to Karlsruhe using a bounding box
- allow `classify_query` to match stops with a lower cutoff before geocoding

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d10b7bfa8832e9d1ab971376b3c7a