### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ können gemeinsam installiert werden mit
 pip install -r requirements.txt
 ```
 
+Alternativ kann das Skript `setup.sh` verwendet werden, das die Installation
+automatisch durchführt:
+
+```bash
+./setup.sh
+```
+
+Mit dem Zusatz `--with-optional` werden auch die optionalen Pakete
+installiert.
+
 Für die optionale Visualisierung werden die Pakete `osmnx` und `folium` benötigt:
 
 ```bash

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Setup script for the project. Installs required dependencies.
+set -e
+
+# Determine python interpreter
+PYTHON=${PYTHON:-python3}
+
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+    echo "Python interpreter '$PYTHON' not found. Please install Python 3." >&2
+    exit 1
+fi
+
+# Upgrade pip and install mandatory requirements
+$PYTHON -m pip install --upgrade pip
+$PYTHON -m pip install -r requirements.txt
+
+if [ "$1" = "--with-optional" ]; then
+    # Install optional packages used for visualization and geocoding
+    $PYTHON -m pip install osmnx folium geopy
+fi
+
+echo "Setup complete"


### PR DESCRIPTION
## Summary
- add `setup.sh` to automate installing dependencies
- document setup script usage in README

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_685e7b403bf4832eba27291bcb655118